### PR TITLE
Support for Feb 2020 update (the one with BB8)

### DIFF
--- a/OpenGameCamera/OpenGameCamera.vcxproj
+++ b/OpenGameCamera/OpenGameCamera.vcxproj
@@ -115,6 +115,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/OpenGameCamera/SigScan/StaticOffsets.h
+++ b/OpenGameCamera/SigScan/StaticOffsets.h
@@ -22,8 +22,6 @@ class StaticOffsets {
 public:
 	AddOffset(OFFSET_GAMERENDERER, "48 8B 0D [?? ?? ?? ?? 48 85 C9 74 0E 48 8B 01 48 8D 15 ?? ?? ??", PatternType::RelativePointer)
 	AddOffset(OFFSET_FIRSTTYPEINFO, "48 8B 05 [?? ?? ?? ?? 48 89 41 08 48 89 0D ?? ?? ?? ??", PatternType::RelativePointer)
-	AddOffset(OFFSET_CAMERAHOOK, "[E8 ?? ?? ?? ?? 48 8D 97 F0 04 00 00 48 8D 8E 00 05 00 00", PatternType::Address)
-	AddOffset(OFFSET_CAMERAHOOK2, "[E8 ?? ?? ?? ?? 48 8D 8F F0 04 00 00 49 8D 97 F0 04 00 00", PatternType::Address)
 	AddOffset(OFFSET_DXRENDERER, "48 8B 0D [?? ?? ?? ?? 44 89 74 24 50 44 89 74", PatternType::RelativePointer)
 	AddOffset(OFFSET_UISETTINGS, "48 89 05 [?? ?? ?? ?? 48 8B 48 28 E8 ?? ?? ?? ?? 41 0F B6 D4", PatternType::RelativePointer)
 	AddOffset(OFFSET_GAMETIMESETTINGS, "48 89 05 [?? ?? ?? ?? C7 40 ?? ?? ?? ?? ?? 8B 43 18", PatternType::RelativePointer)
@@ -36,6 +34,7 @@ public:
 	AddFuncCall(OFFSET_DRAWLINE, "[E8 ?? ?? ?? ?? FF C3 8B 0D ?? ?? ?? ?? FF C9", PatternType::Address)
 	AddFuncCall(OFFSET_DRAWRECT2D, "[E8 ?? ?? ?? ?? C7 87 ?? ?? 00 00 37", PatternType::Address)
 	AddFuncCall(OFFSET_DRAWTEXT, "[E8 ?? ?? ?? ?? 83 C7 14 48 8D 76 04 4D 8D 76 08 49 83 ED 01", PatternType::Address)
+	AddFuncCall(OFFSET_CAMERAHOOK2, "[E8 ?? ?? ?? ?? 4C 8B 4C 24 28 41 0F B6 41 07", PatternType::Address)
 };
 
 // to-do: generate signatures for these

--- a/OpenGameCamera/SigScan/StaticOffsets.h
+++ b/OpenGameCamera/SigScan/StaticOffsets.h
@@ -22,19 +22,20 @@ class StaticOffsets {
 public:
 	AddOffset(OFFSET_GAMERENDERER, "48 8B 0D [?? ?? ?? ?? 48 85 C9 74 0E 48 8B 01 48 8D 15 ?? ?? ??", PatternType::RelativePointer)
 	AddOffset(OFFSET_FIRSTTYPEINFO, "48 8B 05 [?? ?? ?? ?? 48 89 41 08 48 89 0D ?? ?? ?? ??", PatternType::RelativePointer)
-	AddOffset(OFFSET_CAMERAHOOK, "49 8B D6 48 C1 E3 08 48 03 9F ?? ?? ?? ?? 48 8B CB E8 [?? ?? ?? ?? 4C 8B 4C 24 28 41 0F B6 41 07", PatternType::RelativePointer)
-	AddOffset(OFFSET_DXRENDERER, "48 8B 0D [?? ?? ?? ?? 48 8D 55 C0 4C 8B 75 C0", PatternType::RelativePointer)
+	AddOffset(OFFSET_CAMERAHOOK, "[E8 ?? ?? ?? ?? 48 8D 97 F0 04 00 00 48 8D 8E 00 05 00 00", PatternType::Address)
+	AddOffset(OFFSET_CAMERAHOOK2, "[E8 ?? ?? ?? ?? 48 8D 8F F0 04 00 00 49 8D 97 F0 04 00 00", PatternType::Address)
+	AddOffset(OFFSET_DXRENDERER, "48 8B 0D [?? ?? ?? ?? 44 89 74 24 50 44 89 74", PatternType::RelativePointer)
+	AddOffset(OFFSET_UISETTINGS, "48 89 05 [?? ?? ?? ?? 48 8B 48 28 E8 ?? ?? ?? ?? 41 0F B6 D4", PatternType::RelativePointer)
 	AddOffset(OFFSET_GAMETIMESETTINGS, "48 89 05 [?? ?? ?? ?? C7 40 ?? ?? ?? ?? ?? 8B 43 18", PatternType::RelativePointer)
 	AddOffset(OFFSET_INPUTSETTINGS, "48 89 05 [?? ?? ?? ?? 80 B8 A5 00 00 00 00 F3 0F 10 35 ?? ?? ?? ?? 74 ??", PatternType::RelativePointer)
-	AddOffset(OFFSET_KEYBOARDUPDATE, "[48 89 5C 24 08 57 48 83 EC 20 89 D7 48 89 CB 4D 85 C0 75 ?? E8 ?? ?? ?? ?? 48 89 C1 E8 ?? ?? ?? ?? 49 89 C0 83 BB B8 00 00 00 00 75 ?? 49 8B 00 4C 89 C1 40 0F B6 D7 FF 50 30 84 C0 74 ?? B0 01", PatternType::Address)
+	AddOffset(OFFSET_KEYBOARDUPDATE, "[48 89 5C 24 08 57 48 83 EC 20 89 D7 48 89 CB 4D 85 C0 75 ?? E8 ?? ?? ?? ?? 48 89 C1 E8 ?? ?? ?? ?? 49 89 C0 83 BB B8 00 00 00 00 75 ?? 49 8B 00 4C 89 C1 40 0F B6 D7 FF 50 30 84 C0 74 ?? B8 01 00 00 00", PatternType::Address)
 	AddOffset(OFFSET_SETMOUSESTATE, "[53 48 83 EC 20 48 89 CB 48 8B 0D ?? ?? ?? ?? 48 85 C9 0F 84", PatternType::Address)
 	AddOffset(OFFSET_POSTPROCESSSUB, "[41 8B 80 88 00 00 00 89 81 88 00 00 00 41 8B 80 8C 00 00 00 89 81 8C 00 00 00 41 0F B6 80 14 02 00 00", PatternType::Address)
 
-	AddFuncCall(OFFSET_DEBUGRENDERER2, "[E8 ?? ?? ?? ?? 4C 8B F0 48 85 C0 0F ?? ?? ?? ?? ?? F3 0F 10 05 ?? ?? ?? ?? F3", PatternType::Address)
+	AddFuncCall(OFFSET_DEBUGRENDERER2, "[E8 ?? ?? ?? ?? 48 8B 97 30 79 00 00", PatternType::Address)
 	AddFuncCall(OFFSET_DRAWLINE, "[E8 ?? ?? ?? ?? FF C3 8B 0D ?? ?? ?? ?? FF C9", PatternType::Address)
 	AddFuncCall(OFFSET_DRAWRECT2D, "[E8 ?? ?? ?? ?? C7 87 ?? ?? 00 00 37", PatternType::Address)
 	AddFuncCall(OFFSET_DRAWTEXT, "[E8 ?? ?? ?? ?? 83 C7 14 48 8D 76 04 4D 8D 76 08 49 83 ED 01", PatternType::Address)
-	AddFuncCall(OFFSET_CAMERAHOOK2, "[E8 ?? ?? ?? ?? 48 03 DE 48 8B D3 48 8D 8D A0 2D 00 00", PatternType::Address)
 };
 
 // to-do: generate signatures for these

--- a/OpenGameCamera/Source.cpp
+++ b/OpenGameCamera/Source.cpp
@@ -202,6 +202,7 @@ __int64 __fastcall hkupdateCamera2(__int64 a1, CameraObject* a2)
 		// set the origin vector to our global vec4 override
 		a2->cameraTransform.o = g_CameraPosition;
 	}
+
 	return oupdateCamera2(a1, a2);
 }
 
@@ -380,7 +381,6 @@ DWORD __stdcall mainThread(HMODULE hOwnModule)
 	std::cout << std::hex << "OFFSET_KEYBOARDUPDATE:\t0x" << StaticOffsets::Get_OFFSET_KEYBOARDUPDATE() << std::endl;
 	std::cout << std::hex << "OFFSET_SETMOUSESTATE:\t0x" << StaticOffsets::Get_OFFSET_SETMOUSESTATE() << std::endl;
 	std::cout << std::hex << "OFFSET_POSTPROCESSSUB:\t0x" << StaticOffsets::Get_OFFSET_POSTPROCESSSUB() << std::endl;
-	std::cout << std::hex << "OFFSET_CAMERAHOOK:\t0x" << StaticOffsets::Get_OFFSET_CAMERAHOOK() << std::endl;
 	std::cout << std::hex << "OFFSET_CAMERAHOOK2:\t0x" << StaticOffsets::Get_OFFSET_CAMERAHOOK2() << std::endl;
 
 	// build our menu
@@ -388,8 +388,7 @@ DWORD __stdcall mainThread(HMODULE hOwnModule)
 	buildDofMenu(dofMenu);
 	// hook the function for setting our camera position manually
 	// TODO(cstdr1): camerahook is still broken, investigating 
-	//Candy::CreateHook(StaticOffsets::Get_OFFSET_CAMERAHOOK(), &hkupdateCamera2, &oupdateCamera2);
-	//Candy::CreateHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2(), &hkupdateCamera2, &oupdateCamera2);
+	Candy::CreateHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2(), &hkupdateCamera2, &oupdateCamera2);
 
 	// hook the function where keyboard input is processed
 	Candy::CreateHook(StaticOffsets::Get_OFFSET_KEYBOARDUPDATE(), &hkkeyboardUpdate, &okeyboardUpdate);
@@ -423,8 +422,7 @@ DWORD __stdcall mainThread(HMODULE hOwnModule)
 			// now unhook everything we hooked
 			Renderer::shutdown();
 			// TODO(cstdr1): camerahook is still broken, investigating 
-			//Candy::DestroyHook(StaticOffsets::Get_OFFSET_CAMERAHOOK());
-			//Candy::DestroyHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2());
+			Candy::DestroyHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2());
 			Candy::DestroyHook(StaticOffsets::Get_OFFSET_KEYBOARDUPDATE());
 			Candy::DestroyHook(StaticOffsets::Get_OFFSET_SETMOUSESTATE());
 			Candy::DestroyHook(StaticOffsets::Get_OFFSET_POSTPROCESSSUB());

--- a/OpenGameCamera/Source.cpp
+++ b/OpenGameCamera/Source.cpp
@@ -190,7 +190,7 @@ void buildDofMenu(Menu& menu) {
 }
 
 // Camera Update function
-__int64 __fastcall hkupdateCamera2(__int64 a1, CameraObject* a2)
+__int64 __fastcall hkupdateCamera2(CameraObject* a1, CameraObject* a2)
 {
 	// if the camera position hasn't been set,
 	if (g_CameraPosition.x == 0) {

--- a/OpenGameCamera/Source.cpp
+++ b/OpenGameCamera/Source.cpp
@@ -374,18 +374,22 @@ DWORD __stdcall mainThread(HMODULE hOwnModule)
 	std::cout << std::hex << "OFFSET_DRAWRECT2D:\t0x" << StaticOffsets::Get_OFFSET_DRAWRECT2D() << std::endl;
 	std::cout << std::hex << "OFFSET_DRAWTEXT:\t0x" << StaticOffsets::Get_OFFSET_DRAWTEXT() << std::endl;
 	std::cout << std::hex << "OFFSET_GAMERENDERER:\t0x" << StaticOffsets::Get_OFFSET_GAMERENDERER() << std::endl;
+	std::cout << std::hex << "OFFSET_UISETTINGS:\t0x" << StaticOffsets::Get_OFFSET_UISETTINGS() << std::endl;
 	std::cout << std::hex << "OFFSET_GAMETIMESETTINGS:\t0x" << StaticOffsets::Get_OFFSET_GAMETIMESETTINGS() << std::endl;
 	std::cout << std::hex << "OFFSET_INPUTSETTINGS:\t0x" << StaticOffsets::Get_OFFSET_INPUTSETTINGS() << std::endl;
 	std::cout << std::hex << "OFFSET_KEYBOARDUPDATE:\t0x" << StaticOffsets::Get_OFFSET_KEYBOARDUPDATE() << std::endl;
 	std::cout << std::hex << "OFFSET_SETMOUSESTATE:\t0x" << StaticOffsets::Get_OFFSET_SETMOUSESTATE() << std::endl;
 	std::cout << std::hex << "OFFSET_POSTPROCESSSUB:\t0x" << StaticOffsets::Get_OFFSET_POSTPROCESSSUB() << std::endl;
+	std::cout << std::hex << "OFFSET_CAMERAHOOK:\t0x" << StaticOffsets::Get_OFFSET_CAMERAHOOK() << std::endl;
 	std::cout << std::hex << "OFFSET_CAMERAHOOK2:\t0x" << StaticOffsets::Get_OFFSET_CAMERAHOOK2() << std::endl;
 
 	// build our menu
 	buildMainMenu(mainMenu);
 	buildDofMenu(dofMenu);
 	// hook the function for setting our camera position manually
-	Candy::CreateHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2(), &hkupdateCamera2, &oupdateCamera2);
+	// TODO(cstdr1): camerahook is still broken, investigating 
+	//Candy::CreateHook(StaticOffsets::Get_OFFSET_CAMERAHOOK(), &hkupdateCamera2, &oupdateCamera2);
+	//Candy::CreateHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2(), &hkupdateCamera2, &oupdateCamera2);
 
 	// hook the function where keyboard input is processed
 	Candy::CreateHook(StaticOffsets::Get_OFFSET_KEYBOARDUPDATE(), &hkkeyboardUpdate, &okeyboardUpdate);
@@ -418,7 +422,9 @@ DWORD __stdcall mainThread(HMODULE hOwnModule)
 			printf("Unhooking\n");
 			// now unhook everything we hooked
 			Renderer::shutdown();
-			Candy::DestroyHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2());
+			// TODO(cstdr1): camerahook is still broken, investigating 
+			//Candy::DestroyHook(StaticOffsets::Get_OFFSET_CAMERAHOOK());
+			//Candy::DestroyHook(StaticOffsets::Get_OFFSET_CAMERAHOOK2());
 			Candy::DestroyHook(StaticOffsets::Get_OFFSET_KEYBOARDUPDATE());
 			Candy::DestroyHook(StaticOffsets::Get_OFFSET_SETMOUSESTATE());
 			Candy::DestroyHook(StaticOffsets::Get_OFFSET_POSTPROCESSSUB());
@@ -431,6 +437,8 @@ DWORD __stdcall mainThread(HMODULE hOwnModule)
 			FreeLibraryAndExitThread(hOwnModule, 0);
 		}
 	}
+
+	return 0;
 };
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)

--- a/OpenGameCamera/Typedefs.hpp
+++ b/OpenGameCamera/Typedefs.hpp
@@ -5,7 +5,7 @@
 typedef DWORD64(__fastcall* tEndFrame)(void*, DWORD64 a2, bool presentEnable);
 tEndFrame oEndFrame = nullptr;
 
-typedef __int64(*__fastcall tupdateCamera2)(__int64, class CameraObject*);
+typedef __int64(*__fastcall tupdateCamera2)(class CameraObject*, class CameraObject*);
 tupdateCamera2 oupdateCamera2 = nullptr;
 
 typedef bool(*__fastcall tkeyboardUpdate)(__int64, unsigned __int8, __int64);

--- a/OpenGameCamera/sdk.hpp
+++ b/OpenGameCamera/sdk.hpp
@@ -65,7 +65,7 @@ public:
 	bool drawEnable;
 	// static method to return the default instance, from an offset of GameTimeSettings's pointer
 	static UISettings* GetInstance(void) {
-		return *(UISettings**)(StaticOffsets::Get_OFFSET_GAMETIMESETTINGS() + 0x10);
+		return *(UISettings**)(StaticOffsets::Get_OFFSET_UISETTINGS());
 	}
 };
 

--- a/OpenGameCamera/sdk.hpp
+++ b/OpenGameCamera/sdk.hpp
@@ -18,6 +18,7 @@ public:
 	char pad_0000[1304]; //0x0000
 	class GameRenderSettings* gameRenderSettings; //0x0510
 	char pad_0520[24]; //0x0520
+	// NOTE(cstdr1): Below is the transform for showing the camera location
 	class RenderView* renderView; //0x0538
 	char pad_0540[4872]; //0x0540
 	// static method to return the default instance


### PR DESCRIPTION
### Summary
* UISettings pointer is now its own signature to avoid reliance on compiler static variable ordering
* Signatures updated for the Feb 2020 update
* Old CameraHook2 hook was inlined into "WorldRenderModule". New hook only modifies if the "source" matrix is from `GameRenderer->RenderView`
* Release x64 now builds with `/MT`